### PR TITLE
Add query param serializer to work with openapi handling of query parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-react-query/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-react-query/apis.mustache
@@ -50,8 +50,20 @@ export const {{nickname}}AxiosRequest = (
       url: '{{{path}}}'{{#pathParams}}.replace(`{${'{{baseName}}'}}`, encodeURIComponent(String(requestParameters.{{paramName}}))){{/pathParams}},
       method: '{{httpMethod}}',
       {{#allParams.0}}
-      params: requestParameters
+      params: requestParameters,
       {{/allParams.0}}
+      // YB: Modify default Axios query parameter serialization
+      paramsSerializer: function paramsSerializer(params) {
+        return Object.keys(params).map((key) => {
+          if (params[key] == undefined) {
+            return null;
+          }          
+          if (Array.isArray(params[key])) {
+            return `${key}=${params[key].map(encodeURIComponent).join(',')}`;
+          }
+          return `${key}=${encodeURIComponent(params[key])}`;
+        }).filter(Boolean).join('&');
+      }
     },
     customAxiosInstance
   );


### PR DESCRIPTION
Currently, OpenApi spec supports the following [serialization for query parameters](https://swagger.io/docs/specification/serialization/). Our cloud app uses the 2nd line in the table in the above link. This means that parameters that take in string arrays should look like this: `foo=bar,baz,bat`. However, the react-query generator uses axios and, by default, produces url strings like this instead: `foo[]=bar&foo[]=baz&foo[]=bat`. This change explicitly converts the axios default to use the correct serialization that OpenApi supports.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
